### PR TITLE
Fix serve command due to misconfigured bundle path

### DIFF
--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@techdocs/cli",
   "description": "Utility CLI for managing TechDocs sites in Backstage.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/techdocs-cli/src/commands/serve/serve.ts
+++ b/packages/techdocs-cli/src/commands/serve/serve.ts
@@ -83,10 +83,7 @@ export default async function serve(cmd: Command) {
 
   // Run the embedded-techdocs Backstage app
   const techdocsPreviewBundlePath = path.join(
-    __dirname,
-    "..",
-    "..",
-    "..",
+    path.dirname(require.resolve("@techdocs/cli/package.json")),
     "dist",
     "techdocs-preview-bundle"
   );


### PR DESCRIPTION
The path of the Backstage app bundle would not work when @techdocs/cli package will be bundled for release. Previously, by pure co-incidence the path was the same when developing locally as well as after bundling for release.