### PR TITLE
Make it easy to use techdocs-cli in CI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM spotify/techdocs:latest
+
+RUN apk add --update nodejs npm && npm install -g @techdocs/cli
+
+WORKDIR /workspace/
+
+ENTRYPOINT [ "techdocs-cli" ]


### PR DESCRIPTION
# Motivation

I need to integrate techdocs-cli into our Jenkins pipeline. We have the ability to run any docker container image. Other CI tools like GitHub Actions and CircleCI also have the same ability. We can also install executables as part of the CI process but this adds build time overhead to each CI job. Instead, I would like to be able use techdoc-cli that is distributed as a container image. 

I created a spike to see what this would look here.

## Approach

You can build this image with,

```sh
cd docker;
docker build -t techdocs-cli .
```

This will create a local image that you can use to run your CLI. To use this image,

```sh
cd your_project;
docker run -v $(pwd):/workspace/ build --no-docker
```

This will execute execute build command on your techdocs-cli within the docker container.

This base image could be used to create a GitHub Action for techdocs-cli. This would simplify the workflow script from

```yaml
name: Publish TechDocs Site

on:
  push:
    branches: [main]
    # You can even set it to run only when TechDocs related files are updated.
    # paths:
    #   - "docs/**"
    #   - "mkdocs.yml"

jobs:
  publish-techdocs-site:
    runs-on: ubuntu-latest

    # The following secrets are required in your CI environment for publishing files to AWS S3.
    # e.g. You can use GitHub Organization secrets to set them for all existing and new repositories.
    env:
      TECHDOCS_S3_BUCKET_NAME: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
      AWS_REGION: ${{ secrets.AWS_REGION }}
      ENTITY_NAMESPACE: 'default'
      ENTITY_KIND: 'Component'
      ENTITY_NAME: 'my-doc-entity'
      # In a Software template, Scaffolder will replace {{cookiecutter.component_id | jsonify}}
      # with the correct entity name. This is same as metadata.name in the entity's catalog-info.yaml
      # ENTITY_NAME: '{{ cookiecutter.component_id | jsonify }}'

    steps:
      - name: Checkout code
        uses: actions/checkout@v2

      - uses: actions/setup-node@v2
      - uses: actions/setup-python@v2

      - name: Install techdocs-cli
        run: sudo npm install -g @techdocs/cli

      - name: Install mkdocs and mkdocs plugins
        run: python -m pip install mkdocs-techdocs-core==0.*

      - name: Generate docs site
        run: techdocs-cli generate --no-docker --verbose

      - name: Publish docs site
        run:
          techdocs-cli publish --publisher-type awsS3 --storage-name
          $TECHDOCS_S3_BUCKET_NAME --entity
          $ENTITY_NAMESPACE/$ENTITY_KIND/$ENTITY_NAME
```

to something like this,

```yaml
name: Publish TechDocs Site

on:
  push:
    branches: [main]
    # You can even set it to run only when TechDocs related files are updated.
    # paths:
    #   - "docs/**"
    #   - "mkdocs.yml"

jobs:
  publish-techdocs-site:
    runs-on: ubuntu-latest

    # The following secrets are required in your CI environment for publishing files to AWS S3.
    # e.g. You can use GitHub Organization secrets to set them for all existing and new repositories.
    env:
      TECHDOCS_S3_BUCKET_NAME: ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
      AWS_REGION: ${{ secrets.AWS_REGION }}
      ENTITY_NAMESPACE: 'default'
      ENTITY_KIND: 'Component'
      ENTITY_NAME: 'my-doc-entity'
      # In a Software template, Scaffolder will replace {{cookiecutter.component_id | jsonify}}
      # with the correct entity name. This is same as metadata.name in the entity's catalog-info.yaml
      # ENTITY_NAME: '{{ cookiecutter.component_id | jsonify }}'

    steps:
      - name: Checkout code
        uses: actions/checkout@v2

      - name: Publish docs site
        uses: backstage/techdocs-cli
        with:
          args: |
            publish --publisher-type awsS3 \
              --storage-name ${{ secrets.TECHDOCS_S3_BUCKET_NAME }}--entity \
              default/Component/my-doc-entity
```

Note: this probably wouldn't be the arguments that the action would accept but it makes for a better comparison.