### PR TITLE
Update wording on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ By default, Docker and [techdocs-container](https://github.com/backstage/techdoc
 
 The command starts two local servers - an MkDocs preview server on port 8000 and a Backstage app server on port 3000. The Backstage app has a custom TechDocs API implementation, which uses the MkDocs preview server as a proxy to fetch the generated documentation files and assets.
 
+Command reference:
+
 ```bash
 techdocs-cli serve --help
 Usage: techdocs-cli serve [options]
@@ -82,7 +84,7 @@ The generate command uses the [`@backstage/techdocs-common`](https://github.com/
 
 By default, this command uses Docker and [techdocs-container](https://github.com/backstage/techdocs-container) to make sure all the dependencies are installed. But it can be disabled using `--no-docker` flag.
 
-Command reference -
+Command reference:
 
 ```bash
 techdocs-cli generate --help
@@ -110,10 +112,20 @@ Options:
 ### Publish generated TechDocs sites
 
 ```bash
-# Example
 techdocs-cli publish --publisher-type <awsS3|googleGcs|azureBlobStorage> --storage-name <bucket/container name> --entity <namespace/kind/name>
+```
 
-# Command reference
+After generating a TechDocs site using `techdocs-cli generate`, use the publish command to upload the static generated files on a cloud storage
+(AWS/GCS) bucket or (Azure) container which your Backstage app can read from.
+
+The value for `--entity` must be the Backstage entity which the generated TechDocs site belongs to. You can find the values in your Entity's `catalog-info.yaml` file. If namespace is missing in the `catalog-info.yaml`, use `default`.
+The directory structure used in the storage bucket is `namespace/kind/name/<files>`.
+
+Note that the values are case-sensitive. An example for `--entity` is `default/Component/<entityName>`.
+
+Command reference:
+
+```bash
 Usage: techdocs-cli publish [options]
 
 Publish generated TechDocs site to an external storage AWS S3, Google GCS, etc.
@@ -141,17 +153,9 @@ Options:
   -h, --help                               display help for command
 ```
 
-After generating a TechDocs site using `techdocs-cli generate`, use the publish command to upload the static generated files on a cloud storage
-(AWS/GCS) bucket or (Azure) container which your Backstage app can read from.
-
-The value for `--entity` must be the Backstage entity which the generated TechDocs site belongs to. You can find the values in your Entity's `catalog-info.yaml` file. If namespace is missing in the `catalog-info.yaml`, use `default`.
-The directory structure used in the storage bucket is `namespace/kind/name/<files>`.
-
-Note that the values are case-sensitive. An example for `--entity` is `default/Component/<entityName>`.
-
 #### Authentication
 
-You need to make sure that your environment is able to authenticate with GCP/AWS. `techdocs-cli` uses the official Node.js clients provided by AWS (v2), Google Cloud and Azure. You can authenticate using
+You need to make sure that your environment is able to authenticate with the target cloud provider. `techdocs-cli` uses the official Node.js clients provided by AWS (v2), Google Cloud and Azure. You can authenticate using
 environment variables and/or by other means (`~/.aws/credentials`, `~/.config/gcloud` etc.)
 
 Refer to the Authentication section of the following documentation depending upon your cloud storage provider -
@@ -159,25 +163,6 @@ Refer to the Authentication section of the following documentation depending upo
 - [Google Cloud Storage](https://backstage.io/docs/features/techdocs/using-cloud-storage#configuring-google-gcs-bucket-with-techdocs)
 - [AWS S3](https://backstage.io/docs/features/techdocs/using-cloud-storage#configuring-aws-s3-bucket-with-techdocs)
 - [Azure Blob Storage](https://backstage.io/docs/features/techdocs/using-cloud-storage#configuring-azure-blob-storage-container-with-techdocs)
-
-```bash
-techdocs-cli publish --help
-Usage: techdocs-cli publish [options]
-
-Publish generated TechDocs site to an external storage AWS S3, Google GCS, etc.
-
-Options:
-  --publisher-type <TYPE>                 (Required) awsS3 | googleGcs - same as
-                                          techdocs.publisher.type in Backstage app-config.yaml
-  --storage-name <BUCKET/CONTAINER NAME>  (Required) In case of AWS/GCS, use the bucket name.
-                                          Same as techdocs.publisher.[TYPE].bucketName
-  --entity <NAMESPACE/KIND/NAME>          (Required) Entity uid separated by / in
-                                          namespace/kind/name order (case-sensitive). Example:
-                                          default/Component/myEntity
-  --directory <PATH>                      Path of the directory containing generated files to
-                                          publish (default: "./site/")
-  -h, --help                              display help for command
-```
 
 ## Development
 
@@ -236,7 +221,7 @@ Note that the Backstage app and plugins versions are fixed in the `packages/embe
 
 The `techdocs-cli` package currently has a bit of a weird setup. It consists of two monorepos. The first one is the top level monorepo, where each package is listed in the `packages` directory. The second monorepo is a backstage app monorepo which can be found in `packages/embedded-techdocs`.
 
-When we build techdocs-cli (using `build.sh` in the root) we first run `yarn run build` in `packages/embedded-techdocs` resulting in a bundle containing the entire backstage application. When we build `packages/techdocs-cli` using `yarn run build`, the embedded-techdocs bundle will be copied over to the `packages/techdocs-cli/dist`.
+When we build techdocs-cli (using `build.sh` in the root) we first run `yarn run build` in `packages/embedded-techdocs` resulting in a bundle containing the entire Backstage application. When we build `packages/techdocs-cli` using `yarn run build`, the `embedded-techdocs` bundle will be copied over to the `packages/techdocs-cli/dist`.
 
 The resulting CLI can be found inside `packages/techdocs-cli/bin`. Use this for local development (by adding an alias in your local shell environment).
 


### PR DESCRIPTION
Tweaks some minor wording, including removing a duplication in the publish section.

Tries to keep consistent across generate and publish, with a quick code fence at top for the command, some description, and then the full command reference.

Signed-off-by: Adam Harvey <adam.harvey@dxc.com>