### PR TITLE
Fix bug when running serve:mkdocs from directory including spaces

### DIFF
--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@techdocs/cli",
   "description": "Utility CLI for managing TechDocs sites in Backstage.",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/techdocs-cli/src/lib/mkdocsServer.test.ts
+++ b/packages/techdocs-cli/src/lib/mkdocsServer.test.ts
@@ -1,0 +1,55 @@
+import { runMkdocsServer } from './mkdocsServer';
+import { run } from './run';
+
+jest.mock('./run', () => {
+  return {
+    run: jest.fn(),
+  };
+});
+
+describe('runMkdocsServer', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('docker', () => {
+    it('should run docker directly by default', async () => {
+      await runMkdocsServer({});
+
+      const quotedCwd = `'${process.cwd()}':/content`;
+      expect(run).toHaveBeenCalledWith('docker', expect.arrayContaining([
+        'run',
+        quotedCwd,
+        '8000:8000',
+        'serve',
+        '--dev-addr',
+        '0.0.0.0:8000',
+      ]), expect.objectContaining({}));
+    });
+
+    it('should accept port option', async () => {
+      await runMkdocsServer({ port: '5678'});
+      expect(run).toHaveBeenCalledWith('docker', expect.arrayContaining([
+        '5678:5678',
+        '0.0.0.0:5678',
+      ]), expect.objectContaining({}));
+    });
+  });
+
+  describe('mkdocs', () => {
+    it('should run mkdocs if specified ', async () => {
+      await runMkdocsServer({ useDocker: false });
+
+      expect(run).toHaveBeenCalledWith('mkdocs', expect.arrayContaining([
+        'serve', '--dev-addr', '127.0.0.1:8000',
+      ]), expect.objectContaining({}));
+    });
+
+    it('should accept port option', async () => {
+      await runMkdocsServer({ useDocker: false, port: '5678'});
+      expect(run).toHaveBeenCalledWith('mkdocs', expect.arrayContaining([
+        '127.0.0.1:5678',
+      ]), expect.objectContaining({}));
+    });
+  });
+});

--- a/packages/techdocs-cli/src/lib/mkdocsServer.ts
+++ b/packages/techdocs-cli/src/lib/mkdocsServer.ts
@@ -33,7 +33,7 @@ export const runMkdocsServer = async (options: {
         "-w",
         "/content",
         "-v",
-        `${process.cwd()}:/content`,
+        `'${process.cwd()}':/content`,
         "-p",
         `${port}:${port}`,
         "spotify/techdocs",


### PR DESCRIPTION
Signed-off-by: Emma Indal <emmai@spotify.com>

closes: #45 


I did plan to write a test for this, something like

 ```
 it("can serve:mkdocs from dir with spaces", async () => {
    jest.setTimeout(10000);
    const proc = await executeTechDocsCliCommand(["serve:mkdocs"], {
      cwd: "./src/mocks/mock docs",
      killAfter: 8000
    });

    expect(proc.combinedStdOutErr).toContain("Starting mkdocs server on");
  });
```

but since this only happens when using docker and not when using the --no-docker flag, we need to depend on docker in CI I believe, since the e2e test is ran there. Let me know if you think we should do that or skip the test!