### PR TITLE
Fix broken image link in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ techdocs-cli [command]
 techdocs-cli serve
 ```
 
-![A preview of techdocs-cli serve command](.github/assets/techdocs-cli-serve-preview.png)
+![A preview of techdocs-cli serve command](../.github/assets/techdocs-cli-serve-preview.png)
 
 By default, Docker and [techdocs-container](https://github.com/backstage/techdocs-container) is used to make sure all the dependencies are installed. However, Docker can be disabled with `--no-docker` flag.
 


### PR DESCRIPTION
Signed-off-by: Adam Harvey <adaharve@cisco.com>

Fixes a broken image link in the README.  Using the new GitHub feature where the main README can actually come from `docs/README.md`, the referenced image is now one folder too deep. Just linked it back up to root to get to the `/.github` root folder, and it now looks good in my fork.

| Before | After |
| --- | --- |
| <img width="660" alt="image" src="https://user-images.githubusercontent.com/33203301/118316695-23604200-b4c5-11eb-9585-7f07746d256f.png"> | <img width="660" alt="image" src="https://user-images.githubusercontent.com/33203301/118316745-31ae5e00-b4c5-11eb-9822-38e04ad89f8f.png"> |