### PR TITLE
feat: support custom docker images

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,18 +58,21 @@ By default, Docker and [techdocs-container](https://github.com/backstage/techdoc
 
 The command starts two local servers - an MkDocs preview server on port 8000 and a Backstage app server on port 3000. The Backstage app has a custom TechDocs API implementation, which uses the MkDocs preview server as a proxy to fetch the generated documentation files and assets.
 
+NOTE: When using a custom `techdocs` docker image, make sure the entry point is also `ENTRYPOINT ["mkdocs"]`.
+
 Command reference:
 
 ```bash
-techdocs-cli serve --help
 Usage: techdocs-cli serve [options]
 
 Serve a documentation project locally in a Backstage app-like environment
 
 Options:
-  --no-docker           Do not use docker, use mkdocs executable in current user environment.
-  --mkdocs-port <PORT>  Port for mkdocs server to use (default: "8000")
-  -v --verbose          Enable verbose output. (default: false)
+  -i, --docker-image <DOCKER_IMAGE>  The mkdocs docker container to use (default spotify/techdocs) (default: "spotify/techdocs")
+  --no-docker                        Do not use Docker, use MkDocs executable in current user environment.
+  --mkdocs-port <PORT>               Port for MkDocs server to use (default: "8000")
+  -v --verbose                       Enable verbose output. (default: false)
+  -h, --help                         display help for command
 ```
 
 ### Generate TechDocs site from a documentation project

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -116,6 +116,11 @@ export function registerCommands(program: CommanderStatic) {
     .command("serve:mkdocs")
     .description("Serve a documentation project locally using MkDocs serve.")
     .option(
+      "-i, --docker-image <DOCKER_IMAGE>",
+      "The mkdocs docker container to use (default spotify/techdocs)",
+      "spotify/techdocs"
+    )
+    .option(
       "--no-docker",
       "Do not use Docker, run `mkdocs serve` in current user environment."
     )
@@ -127,6 +132,11 @@ export function registerCommands(program: CommanderStatic) {
     .command("serve")
     .description(
       "Serve a documentation project locally in a Backstage app-like environment"
+    )
+    .option(
+      "-i, --docker-image <DOCKER_IMAGE>",
+      "The mkdocs docker container to use (default spotify/techdocs)",
+      "spotify/techdocs"
     )
     .option(
       "--no-docker",

--- a/packages/techdocs-cli/src/commands/serve/mkdocs.ts
+++ b/packages/techdocs-cli/src/commands/serve/mkdocs.ts
@@ -59,6 +59,7 @@ export default async function serveMkdocs(cmd: Command) {
   // Commander stores --no-docker in cmd.docker variable
   const childProcess = await runMkdocsServer({
     port: cmd.port,
+    dockerImage: cmd.dockerImage,
     useDocker: cmd.docker,
     stdoutLogFunc: logFunc,
     stderrLogFunc: logFunc

--- a/packages/techdocs-cli/src/commands/serve/serve.ts
+++ b/packages/techdocs-cli/src/commands/serve/serve.ts
@@ -60,6 +60,7 @@ export default async function serve(cmd: Command) {
   logger.info("Starting mkdocs server.");
   const mkdocsChildProcess = await runMkdocsServer({
     port: cmd.mkdocsPort,
+    dockerImage: cmd.dockerImage,
     useDocker: cmd.docker,
     stdoutLogFunc: mkdocsLogFunc,
     stderrLogFunc: mkdocsLogFunc

--- a/packages/techdocs-cli/src/lib/mkdocsServer.test.ts
+++ b/packages/techdocs-cli/src/lib/mkdocsServer.test.ts
@@ -1,55 +1,74 @@
-import { runMkdocsServer } from './mkdocsServer';
-import { run } from './run';
+import { runMkdocsServer } from "./mkdocsServer";
+import { run } from "./run";
 
-jest.mock('./run', () => {
+jest.mock("./run", () => {
   return {
-    run: jest.fn(),
+    run: jest.fn()
   };
 });
 
-describe('runMkdocsServer', () => {
+describe("runMkdocsServer", () => {
   beforeEach(() => {
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
 
-  describe('docker', () => {
-    it('should run docker directly by default', async () => {
+  describe("docker", () => {
+    it("should run docker directly by default", async () => {
       await runMkdocsServer({});
 
       const quotedCwd = `'${process.cwd()}':/content`;
-      expect(run).toHaveBeenCalledWith('docker', expect.arrayContaining([
-        'run',
-        quotedCwd,
-        '8000:8000',
-        'serve',
-        '--dev-addr',
-        '0.0.0.0:8000',
-      ]), expect.objectContaining({}));
+      expect(run).toHaveBeenCalledWith(
+        "docker",
+        expect.arrayContaining([
+          "run",
+          quotedCwd,
+          "8000:8000",
+          "serve",
+          "--dev-addr",
+          "0.0.0.0:8000",
+          "spotify/techdocs"
+        ]),
+        expect.objectContaining({})
+      );
     });
 
-    it('should accept port option', async () => {
-      await runMkdocsServer({ port: '5678'});
-      expect(run).toHaveBeenCalledWith('docker', expect.arrayContaining([
-        '5678:5678',
-        '0.0.0.0:5678',
-      ]), expect.objectContaining({}));
+    it("should accept port option", async () => {
+      await runMkdocsServer({ port: "5678" });
+      expect(run).toHaveBeenCalledWith(
+        "docker",
+        expect.arrayContaining(["5678:5678", "0.0.0.0:5678"]),
+        expect.objectContaining({})
+      );
+    });
+
+    it("should accept custom docker image", async () => {
+      await runMkdocsServer({ dockerImage: "my-org/techdocs" });
+      expect(run).toHaveBeenCalledWith(
+        "docker",
+        expect.arrayContaining(["my-org/techdocs"]),
+        expect.objectContaining({})
+      );
     });
   });
 
-  describe('mkdocs', () => {
-    it('should run mkdocs if specified ', async () => {
+  describe("mkdocs", () => {
+    it("should run mkdocs if specified ", async () => {
       await runMkdocsServer({ useDocker: false });
 
-      expect(run).toHaveBeenCalledWith('mkdocs', expect.arrayContaining([
-        'serve', '--dev-addr', '127.0.0.1:8000',
-      ]), expect.objectContaining({}));
+      expect(run).toHaveBeenCalledWith(
+        "mkdocs",
+        expect.arrayContaining(["serve", "--dev-addr", "127.0.0.1:8000"]),
+        expect.objectContaining({})
+      );
     });
 
-    it('should accept port option', async () => {
-      await runMkdocsServer({ useDocker: false, port: '5678'});
-      expect(run).toHaveBeenCalledWith('mkdocs', expect.arrayContaining([
-        '127.0.0.1:5678',
-      ]), expect.objectContaining({}));
+    it("should accept port option", async () => {
+      await runMkdocsServer({ useDocker: false, port: "5678" });
+      expect(run).toHaveBeenCalledWith(
+        "mkdocs",
+        expect.arrayContaining(["127.0.0.1:5678"]),
+        expect.objectContaining({})
+      );
     });
   });
 });

--- a/packages/techdocs-cli/src/lib/mkdocsServer.ts
+++ b/packages/techdocs-cli/src/lib/mkdocsServer.ts
@@ -19,11 +19,13 @@ import { run, LogFunc } from "./run";
 export const runMkdocsServer = async (options: {
   port?: string;
   useDocker?: boolean;
+  dockerImage?: string;
   stdoutLogFunc?: LogFunc;
   stderrLogFunc?: LogFunc;
 }): Promise<ChildProcess> => {
   const port = options.port ?? "8000";
   const useDocker = options.useDocker ?? true;
+  const dockerImage = options.dockerImage ?? "spotify/techdocs";
 
   if (useDocker) {
     return await run(
@@ -36,7 +38,7 @@ export const runMkdocsServer = async (options: {
         `'${process.cwd()}':/content`,
         "-p",
         `${port}:${port}`,
-        "spotify/techdocs",
+        dockerImage,
         "serve",
         "--dev-addr",
         `0.0.0.0:${port}`


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds new `--docker-image` command line switches to support a custom docker image. This can be useful if you want to support custom MkDocs plugins or external tools.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

