### PR TITLE
feat: add new options in order to use openstackswift publisher

### DIFF
--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -51,7 +51,7 @@ export function registerCommands(program: CommanderStatic) {
     )
     .requiredOption(
       "--publisher-type <TYPE>",
-      "(Required always) awsS3 | googleGcs | azureBlobStorage - same as techdocs.publisher.type in Backstage app-config.yaml"
+      "(Required always) awsS3 | googleGcs | azureBlobStorage | openStackSwift - same as techdocs.publisher.type in Backstage app-config.yaml"
     )
     .requiredOption(
       "--storage-name <BUCKET/CONTAINER NAME>",
@@ -76,6 +76,34 @@ export function registerCommands(program: CommanderStatic) {
     .option(
       "--awsEndpoint <AWS ENDPOINT>",
       "Optional AWS endpoint to send requests to."
+    )
+    .option(
+      "--osUsername <OPENSTACK SWIFT USERNAME>",
+      "(Required for OpenStack) specify when --publisher-type openStackSwift"
+    )
+    .option(
+      "--osPassword <OPENSTACK SWIFT PASSWORD>",
+      "(Required for OpenStack) specify when --publisher-type openStackSwift"
+    )
+    .option(
+      "--osAuthUrl <OPENSTACK SWIFT AUTHURL>",
+      "(Required for OpenStack) specify when --publisher-type openStackSwift"
+    )
+    .option(
+      "--osRegion <OPENSTACK SWIFT REGION>",
+      "(Required for OpenStack) specify when --publisher-type openStackSwift"
+    )
+    .option(
+      "--osAuthVersion <OPENSTACK SWIFT AUTHVERSION>",
+      "Optional OpenStack. Default is setted to v3"
+    )
+    .option(
+      "--osDomainId <OPENSTACK SWIFT DOMAIN ID>",
+      "Optional OpenStack. Default is setted to default"
+    )
+    .option(
+      "--osDomainName <OPENSTACK SWIFT DOMAIN NAME>",
+      "Optional OpenStack. Default is setted to Default"
     )
     .option(
       "--directory <PATH>",


### PR DESCRIPTION
# Motivation
**Add openStackSwift publisher type**

`publisher-type` option was setted to accept `awsS3` / `GoogleGcs` / `azureBlobStorage` - same as the variable `techdocs.publisher.type` in backstage config file.
But in backstage config file, there is another option: `openStackSwift` and `techdocs-cli` wasn't ready to accept this option even if `techdocs-common` had everything to handle it.

# Approach

This PR added 7 more options (4 mandatory / 3 optionals) to match the options of openStackSwift storage connector described [here](https://github.com/backstage/backstage/blob/master/packages/techdocs-common/src/stages/publish/openStackSwift.ts#L65)

1. `osUsername` | **Mandatory** (if `openStackSwift`)
2. `osPassword` | **Mandatory** (if `openStackSwift`)
3. `osAuthUrl` | **Mandatory** (if `openStackSwift`)
4. `osRegion` | **Mandatory** (if `openStackSwift`)
5. `osAuthVersion` | Optional
6. `osDomainId` | Optional
7. `osDomainName ` | Optional

A simple check is made for the mandatory options.