### PR TITLE
fix: double docker-image cli description

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -68,7 +68,7 @@ Usage: techdocs-cli serve [options]
 Serve a documentation project locally in a Backstage app-like environment
 
 Options:
-  -i, --docker-image <DOCKER_IMAGE>  The mkdocs docker container to use (default spotify/techdocs) (default: "spotify/techdocs")
+  -i, --docker-image <DOCKER_IMAGE>  The mkdocs docker container to use (default: "spotify/techdocs")
   --no-docker                        Do not use Docker, use MkDocs executable in current user environment.
   --mkdocs-port <PORT>               Port for MkDocs server to use (default: "8000")
   -v --verbose                       Enable verbose output. (default: false)

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -117,7 +117,7 @@ export function registerCommands(program: CommanderStatic) {
     .description("Serve a documentation project locally using MkDocs serve.")
     .option(
       "-i, --docker-image <DOCKER_IMAGE>",
-      "The mkdocs docker container to use (default spotify/techdocs)",
+      "The mkdocs docker container to use",
       "spotify/techdocs"
     )
     .option(
@@ -135,7 +135,7 @@ export function registerCommands(program: CommanderStatic) {
     )
     .option(
       "-i, --docker-image <DOCKER_IMAGE>",
-      "The mkdocs docker container to use (default spotify/techdocs)",
+      "The mkdocs docker container to use",
       "spotify/techdocs"
     )
     .option(


### PR DESCRIPTION
The default value `--docker-image` is automatically appended to the end of the CLI shell output. Since it was included in the text explicitly this shows twice.