### PR TITLE
[Publish] add option awsS3ForcePathStyle

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -151,6 +151,7 @@ Options:
                                            variables.
   --awsRoleArn <AWS ROLE ARN>              Optional AWS ARN of role to be assumed.
   --awsEndpoint <AWS ENDPOINT>             Optional AWS endpoint to send requests to.
+  --awsS3ForcePathStyle                    Optional AWS S3 option to force path style.
   --directory <PATH>                       Path of the directory containing generated files to
                                            publish (default: "./site/")
   -h, --help                               display help for command

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -78,6 +78,10 @@ export function registerCommands(program: CommanderStatic) {
       "Optional AWS endpoint to send requests to."
     )
     .option(
+      "--awsS3ForcePathStyle",
+      "Optional AWS S3 option to force path style."
+    )
+    .option(
       "--osUsername <OPENSTACK SWIFT USERNAME>",
       "(Required for OpenStack) specify when --publisher-type openStackSwift"
     )


### PR DESCRIPTION
Signed-off-by: Camila Belo <camilaibs@gmail.com>

Closes: #80

Allow providers like LocalStack, Minio, Wasabi, and others to use path style when running the _publish_ command with the `--awsS3ForcePathStyle` option:

```bash
# Required flags are omitted in this example
techdocs-cli publish --publisher-type=awsS3 --awsS3ForcePathStyle
```
- [x] create the new option
- [x] use option in the config
- [x] update the documentation
- [ ] create a test for the new changes

