### PR TITLE
fix: required logger in generate

### DIFF
--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -19,13 +19,13 @@ import fs from "fs-extra";
 import Docker from "dockerode";
 import {
   TechdocsGenerator,
-  ParsedLocationAnnotation
+  ParsedLocationAnnotation,
 } from "@backstage/techdocs-common";
 import { DockerContainerRunner } from "@backstage/backend-common";
 import { ConfigReader } from "@backstage/config";
 import {
   convertTechDocsRefToLocationAnnotation,
-  createLogger
+  createLogger,
 } from "../../lib/utility";
 
 export default async function generate(cmd: Command) {
@@ -47,9 +47,9 @@ export default async function generate(cmd: Command) {
   const config = new ConfigReader({
     techdocs: {
       generators: {
-        techdocs: cmd.docker ? "docker" : "local"
-      }
-    }
+        techdocs: cmd.docker ? "docker" : "local",
+      },
+    },
   });
 
   // Docker client (conditionally) used by the generators, based on techdocs.generators config.
@@ -71,7 +71,7 @@ export default async function generate(cmd: Command) {
   const techdocsGenerator = new TechdocsGenerator({
     logger,
     containerRunner,
-    config
+    config,
   });
 
   logger.info("Generating documentation...");
@@ -79,9 +79,12 @@ export default async function generate(cmd: Command) {
   await techdocsGenerator.run({
     inputDir: sourceDir,
     outputDir,
-    ...(cmd.techdocsRef && {
-      parsedLocationAnnotation
-    })
+    ...(cmd.techdocsRef
+      ? {
+          parsedLocationAnnotation,
+        }
+      : {}),
+    logger,
   });
 
   logger.info("Done!");


### PR DESCRIPTION
Fixes #86

The latest backstage release introduced an new required option in the generate step run method https://github.com/backstage/backstage/pull/6341/files#diff-ddd013876d02c04e8ddaad2ac791a0310e9694046c3f8db9235afd648cd86054R64. This is a quick fix. Longer term fix could be to update the `techdocs-common` generator to use the class logger when a logger is not passed directly to the run method.