### PR TITLE
Create legacyUseCaseSensitiveTripletPaths option for publish

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -137,6 +137,12 @@ Options:
   --entity <NAMESPACE/KIND/NAME>           (Required always) Entity uid separated by / in
                                            namespace/kind/name order (case-sensitive). Example:
                                            default/Component/myEntity
+  --legacyUseCaseSensitiveTripletPaths     (Optional and not recommended) Prior to version [0.x.y] of TechDocs, docs
+                                           sites could only be accessed over paths with case-sensitive entity triplets
+                                           e.g. (namespace/Kind/name). If you are upgrading from an older version of
+                                           TechDocs and are unable to perform the necessary migration of files in your
+                                           external storage, you can set this value to "true" to temporarily revert to
+                                           the old, case-sensitive entity triplet behavior
   --azureAccountName <AZURE ACCOUNT NAME>  (Required for Azure) specify when --publisher-type
                                            azureBlobStorage
   --azureAccountKey <AZURE ACCOUNT KEY>    Azure Storage Account key to use for authentication.

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,12 +137,8 @@ Options:
   --entity <NAMESPACE/KIND/NAME>           (Required always) Entity uid separated by / in
                                            namespace/kind/name order (case-sensitive). Example:
                                            default/Component/myEntity
-  --legacyUseCaseSensitiveTripletPaths     (Optional and not recommended) Prior to version [0.x.y] of TechDocs, docs
-                                           sites could only be accessed over paths with case-sensitive entity triplets
-                                           e.g. (namespace/Kind/name). If you are upgrading from an older version of
-                                           TechDocs and are unable to perform the necessary migration of files in your
-                                           external storage, you can set this value to "true" to temporarily revert to
-                                           the old, case-sensitive entity triplet behavior
+  --legacyUseCaseSensitiveTripletPaths     Publishes objects with cased entity triplet prefix when set (e.g. namespace/Kind/name).
+                                           Only use if your TechDocs backend is configured the same way
   --azureAccountName <AZURE ACCOUNT NAME>  (Required for Azure) specify when --publisher-type
                                            azureBlobStorage
   --azureAccountKey <AZURE ACCOUNT KEY>    Azure Storage Account key to use for authentication.

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -140,12 +140,19 @@ export function registerCommands(program: CommanderStatic) {
       "(Required always) Entity uid separated by / in namespace/kind/name order (case-sensitive). Example: default/Component/myEntity "
     )
     .option(
-      "--azureAccountName <AZURE ACCOUNT NAME>",
-      "(Required for Azure) specify when --publisher-type azureBlobStorage"
+      '--legacyUseCaseSensitiveTripletPaths',
+      `
+      (Optional and not recommended) Prior to version [0.x.y] of TechDocs, docs
+      sites could only be accessed over paths with case-sensitive entity triplets
+      e.g. (namespace/Kind/name). If you are upgrading from an older version of
+      TechDocs and are unable to perform the necessary migration of files in your
+      external storage, you can set this value to "true" to temporarily revert to
+      the old, case-sensitive entity triplet behavior.
+      `,
     )
     .option(
-      "--azureAccountKey <AZURE ACCOUNT KEY>",
-      "Azure Storage Account key to use for authentication. If not specified, you must set AZURE_TENANT_ID, AZURE_CLIENT_ID & AZURE_CLIENT_SECRET as environment variables."
+      '--azureAccountName <AZURE ACCOUNT NAME>',
+      '(Required for Azure) specify when --publisher-type azureBlobStorage',
     )
     .option(
       "--awsRoleArn <AWS ROLE ARN>",

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -14,141 +14,136 @@
  * limitations under the License.
  */
 
-import { CommanderStatic } from "commander";
+import { CommanderStatic } from 'commander';
 
 export function registerCommands(program: CommanderStatic) {
   program
-    .command("generate")
-    .description("Generate TechDocs documentation site using MkDocs.")
+    .command('generate')
+    .description('Generate TechDocs documentation site using MkDocs.')
     .option(
-      "--source-dir <PATH>",
-      "Source directory containing mkdocs.yml and docs/ directory.",
-      "."
+      '--source-dir <PATH>',
+      'Source directory containing mkdocs.yml and docs/ directory.',
+      '.',
     )
     .option(
-      "--output-dir <PATH>",
-      "Output directory containing generated TechDocs site.",
-      "./site/"
+      '--output-dir <PATH>',
+      'Output directory containing generated TechDocs site.',
+      './site/',
     )
     .option(
-      "--docker-image <DOCKER_IMAGE>",
-      "The mkdocs docker container to use",
-      "spotify/techdocs"
+      '--docker-image <DOCKER_IMAGE>',
+      'The mkdocs docker container to use',
+      'spotify/techdocs',
     )
-    .option("--no-pull", "Do not pull the latest docker image", false)
+    .option('--no-pull', 'Do not pull the latest docker image', false)
     .option(
-      "--no-docker",
-      "Do not use Docker, use MkDocs executable and plugins in current user environment."
+      '--no-docker',
+      'Do not use Docker, use MkDocs executable and plugins in current user environment.',
     )
     .option(
-      "--techdocs-ref <HOST_TYPE:URL>",
-      "The repository hosting documentation source files e.g. github:https://ghe.mycompany.net.com/org/repo." +
-        "\nThis value is same as the backstage.io/techdocs-ref annotation of the corresponding Backstage entity." +
-        "\nIt is completely fine to skip this as it is only being used to set repo_url in mkdocs.yml if not found.\n"
+      '--techdocs-ref <HOST_TYPE:URL>',
+      'The repository hosting documentation source files e.g. github:https://ghe.mycompany.net.com/org/repo.' +
+        '\nThis value is same as the backstage.io/techdocs-ref annotation of the corresponding Backstage entity.' +
+        '\nIt is completely fine to skip this as it is only being used to set repo_url in mkdocs.yml if not found.\n',
     )
-    .option("-v --verbose", "Enable verbose output.", false)
-    .alias("build")
-    .action(lazy(() => import("./generate/generate").then(m => m.default)));
+    .option('-v --verbose', 'Enable verbose output.', false)
+    .alias('build')
+    .action(lazy(() => import('./generate/generate').then(m => m.default)));
 
   program
-    .command("migrate")
-    .description("Migrate objects with case-sensitive entity triplets to lower-case versions.")
-    .requiredOption(
-      "--publisher-type <TYPE>",
-      "(Required always) awsS3 | googleGcs | azureBlobStorage | openStackSwift - same as techdocs.publisher.type in Backstage app-config.yaml"
-    )
-    .requiredOption(
-      "--storage-name <BUCKET/CONTAINER NAME>",
-      "(Required always) In case of AWS/GCS, use the bucket name. In case of Azure, use container name. Same as techdocs.publisher.[TYPE].bucketName"
-    )
-    .option(
-      "--azureAccountName <AZURE ACCOUNT NAME>",
-      "(Required for Azure) specify when --publisher-type azureBlobStorage"
-    )
-    .option(
-      "--azureAccountKey <AZURE ACCOUNT KEY>",
-      "Azure Storage Account key to use for authentication. If not specified, you must set AZURE_TENANT_ID, AZURE_CLIENT_ID & AZURE_CLIENT_SECRET as environment variables."
-    )
-    .option(
-      "--awsRoleArn <AWS ROLE ARN>",
-      "Optional AWS ARN of role to be assumed."
-    )
-    .option(
-      "--awsEndpoint <AWS ENDPOINT>",
-      "Optional AWS endpoint to send requests to."
-    )
-    .option(
-      "--awsS3ForcePathStyle",
-      "Optional AWS S3 option to force path style."
-    )
-    .option(
-      "--osUsername <OPENSTACK SWIFT USERNAME>",
-      "(Required for OpenStack) specify when --publisher-type openStackSwift"
-    )
-    .option(
-      "--osPassword <OPENSTACK SWIFT PASSWORD>",
-      "(Required for OpenStack) specify when --publisher-type openStackSwift"
-    )
-    .option(
-      "--osAuthUrl <OPENSTACK SWIFT AUTHURL>",
-      "(Required for OpenStack) specify when --publisher-type openStackSwift"
-    )
-    .option(
-      "--osRegion <OPENSTACK SWIFT REGION>",
-      "(Required for OpenStack) specify when --publisher-type openStackSwift"
-    )
-    .option(
-      "--osAuthVersion <OPENSTACK SWIFT AUTHVERSION>",
-      "Optional OpenStack. Default is set to v3"
-    )
-    .option(
-      "--osDomainId <OPENSTACK SWIFT DOMAIN ID>",
-      "Optional OpenStack. Default is set to default"
-    )
-    .option(
-      "--osDomainName <OPENSTACK SWIFT DOMAIN NAME>",
-      "Optional OpenStack. Default is set to Default"
-    )
-    .option(
-      "--removeOriginal",
-      "Optional Files are copied by default. If flag is set, files are renamed/moved instead.",
-      false
-    )
-    .option(
-      "--concurrency <MAX CONCURRENT REQS>",
-      "Optional Controls the number of API requests allowed to be performed simultaneously.",
-      '25'
-    )
-    .option("-v --verbose", "Enable verbose output.", false)
-    .action(lazy(() => import("./migrate/migrate").then(m => m.default)));
-
-  program
-    .command("publish")
+    .command('migrate')
     .description(
-      "Publish generated TechDocs site to an external storage AWS S3, Google GCS, etc."
+      'Migrate objects with case-sensitive entity triplets to lower-case versions.',
     )
     .requiredOption(
-      "--publisher-type <TYPE>",
-      "(Required always) awsS3 | googleGcs | azureBlobStorage | openStackSwift - same as techdocs.publisher.type in Backstage app-config.yaml"
+      '--publisher-type <TYPE>',
+      '(Required always) awsS3 | googleGcs | azureBlobStorage | openStackSwift - same as techdocs.publisher.type in Backstage app-config.yaml',
     )
     .requiredOption(
-      "--storage-name <BUCKET/CONTAINER NAME>",
-      "(Required always) In case of AWS/GCS, use the bucket name. In case of Azure, use container name. Same as techdocs.publisher.[TYPE].bucketName"
+      '--storage-name <BUCKET/CONTAINER NAME>',
+      '(Required always) In case of AWS/GCS, use the bucket name. In case of Azure, use container name. Same as techdocs.publisher.[TYPE].bucketName',
+    )
+    .option(
+      '--azureAccountName <AZURE ACCOUNT NAME>',
+      '(Required for Azure) specify when --publisher-type azureBlobStorage',
+    )
+    .option(
+      '--azureAccountKey <AZURE ACCOUNT KEY>',
+      'Azure Storage Account key to use for authentication. If not specified, you must set AZURE_TENANT_ID, AZURE_CLIENT_ID & AZURE_CLIENT_SECRET as environment variables.',
+    )
+    .option(
+      '--awsRoleArn <AWS ROLE ARN>',
+      'Optional AWS ARN of role to be assumed.',
+    )
+    .option(
+      '--awsEndpoint <AWS ENDPOINT>',
+      'Optional AWS endpoint to send requests to.',
+    )
+    .option(
+      '--awsS3ForcePathStyle',
+      'Optional AWS S3 option to force path style.',
+    )
+    .option(
+      '--osUsername <OPENSTACK SWIFT USERNAME>',
+      '(Required for OpenStack) specify when --publisher-type openStackSwift',
+    )
+    .option(
+      '--osPassword <OPENSTACK SWIFT PASSWORD>',
+      '(Required for OpenStack) specify when --publisher-type openStackSwift',
+    )
+    .option(
+      '--osAuthUrl <OPENSTACK SWIFT AUTHURL>',
+      '(Required for OpenStack) specify when --publisher-type openStackSwift',
+    )
+    .option(
+      '--osRegion <OPENSTACK SWIFT REGION>',
+      '(Required for OpenStack) specify when --publisher-type openStackSwift',
+    )
+    .option(
+      '--osAuthVersion <OPENSTACK SWIFT AUTHVERSION>',
+      'Optional OpenStack. Default is set to v3',
+    )
+    .option(
+      '--osDomainId <OPENSTACK SWIFT DOMAIN ID>',
+      'Optional OpenStack. Default is set to default',
+    )
+    .option(
+      '--osDomainName <OPENSTACK SWIFT DOMAIN NAME>',
+      'Optional OpenStack. Default is set to Default',
+    )
+    .option(
+      '--removeOriginal',
+      'Optional Files are copied by default. If flag is set, files are renamed/moved instead.',
+      false,
+    )
+    .option(
+      '--concurrency <MAX CONCURRENT REQS>',
+      'Optional Controls the number of API requests allowed to be performed simultaneously.',
+      '25',
+    )
+    .option('-v --verbose', 'Enable verbose output.', false)
+    .action(lazy(() => import('./migrate/migrate').then(m => m.default)));
+
+  program
+    .command('publish')
+    .description(
+      'Publish generated TechDocs site to an external storage AWS S3, Google GCS, etc.',
     )
     .requiredOption(
-      "--entity <NAMESPACE/KIND/NAME>",
-      "(Required always) Entity uid separated by / in namespace/kind/name order (case-sensitive). Example: default/Component/myEntity "
+      '--publisher-type <TYPE>',
+      '(Required always) awsS3 | googleGcs | azureBlobStorage | openStackSwift - same as techdocs.publisher.type in Backstage app-config.yaml',
+    )
+    .requiredOption(
+      '--storage-name <BUCKET/CONTAINER NAME>',
+      '(Required always) In case of AWS/GCS, use the bucket name. In case of Azure, use container name. Same as techdocs.publisher.[TYPE].bucketName',
+    )
+    .requiredOption(
+      '--entity <NAMESPACE/KIND/NAME>',
+      '(Required always) Entity uid separated by / in namespace/kind/name order (case-sensitive). Example: default/Component/myEntity ',
     )
     .option(
       '--legacyUseCaseSensitiveTripletPaths',
-      `
-      (Optional and not recommended) Prior to version [0.x.y] of TechDocs, docs
-      sites could only be accessed over paths with case-sensitive entity triplets
-      e.g. (namespace/Kind/name). If you are upgrading from an older version of
-      TechDocs and are unable to perform the necessary migration of files in your
-      external storage, you can set this value to "true" to temporarily revert to
-      the old, case-sensitive entity triplet behavior.
-      `,
+      'Publishes objects with cased entity triplet prefix when set (e.g. namespace/Kind/name). Only use if your TechDocs backend is configured the same way.',
       false,
     )
     .option(
@@ -156,91 +151,91 @@ export function registerCommands(program: CommanderStatic) {
       '(Required for Azure) specify when --publisher-type azureBlobStorage',
     )
     .option(
-      "--awsRoleArn <AWS ROLE ARN>",
-      "Optional AWS ARN of role to be assumed."
+      '--awsRoleArn <AWS ROLE ARN>',
+      'Optional AWS ARN of role to be assumed.',
     )
     .option(
-      "--awsEndpoint <AWS ENDPOINT>",
-      "Optional AWS endpoint to send requests to."
+      '--awsEndpoint <AWS ENDPOINT>',
+      'Optional AWS endpoint to send requests to.',
     )
     .option(
-      "--awsS3ForcePathStyle",
-      "Optional AWS S3 option to force path style."
+      '--awsS3ForcePathStyle',
+      'Optional AWS S3 option to force path style.',
     )
     .option(
-      "--osUsername <OPENSTACK SWIFT USERNAME>",
-      "(Required for OpenStack) specify when --publisher-type openStackSwift"
+      '--osUsername <OPENSTACK SWIFT USERNAME>',
+      '(Required for OpenStack) specify when --publisher-type openStackSwift',
     )
     .option(
-      "--osPassword <OPENSTACK SWIFT PASSWORD>",
-      "(Required for OpenStack) specify when --publisher-type openStackSwift"
+      '--osPassword <OPENSTACK SWIFT PASSWORD>',
+      '(Required for OpenStack) specify when --publisher-type openStackSwift',
     )
     .option(
-      "--osAuthUrl <OPENSTACK SWIFT AUTHURL>",
-      "(Required for OpenStack) specify when --publisher-type openStackSwift"
+      '--osAuthUrl <OPENSTACK SWIFT AUTHURL>',
+      '(Required for OpenStack) specify when --publisher-type openStackSwift',
     )
     .option(
-      "--osRegion <OPENSTACK SWIFT REGION>",
-      "(Required for OpenStack) specify when --publisher-type openStackSwift"
+      '--osRegion <OPENSTACK SWIFT REGION>',
+      '(Required for OpenStack) specify when --publisher-type openStackSwift',
     )
     .option(
-      "--osAuthVersion <OPENSTACK SWIFT AUTHVERSION>",
-      "Optional OpenStack. Default is set to v3"
+      '--osAuthVersion <OPENSTACK SWIFT AUTHVERSION>',
+      'Optional OpenStack. Default is set to v3',
     )
     .option(
-      "--osDomainId <OPENSTACK SWIFT DOMAIN ID>",
-      "Optional OpenStack. Default is set to default"
+      '--osDomainId <OPENSTACK SWIFT DOMAIN ID>',
+      'Optional OpenStack. Default is set to default',
     )
     .option(
-      "--osDomainName <OPENSTACK SWIFT DOMAIN NAME>",
-      "Optional OpenStack. Default is set to Default"
+      '--osDomainName <OPENSTACK SWIFT DOMAIN NAME>',
+      'Optional OpenStack. Default is set to Default',
     )
     .option(
-      "--directory <PATH>",
-      "Path of the directory containing generated files to publish",
-      "./site/"
+      '--directory <PATH>',
+      'Path of the directory containing generated files to publish',
+      './site/',
     )
-    .action(lazy(() => import("./publish/publish").then(m => m.default)));
+    .action(lazy(() => import('./publish/publish').then(m => m.default)));
 
   program
-    .command("serve:mkdocs")
-    .description("Serve a documentation project locally using MkDocs serve.")
+    .command('serve:mkdocs')
+    .description('Serve a documentation project locally using MkDocs serve.')
     .option(
-      "-i, --docker-image <DOCKER_IMAGE>",
-      "The mkdocs docker container to use",
-      "spotify/techdocs"
+      '-i, --docker-image <DOCKER_IMAGE>',
+      'The mkdocs docker container to use',
+      'spotify/techdocs',
     )
     .option(
-      "--no-docker",
-      "Do not use Docker, run `mkdocs serve` in current user environment."
+      '--no-docker',
+      'Do not use Docker, run `mkdocs serve` in current user environment.',
     )
-    .option("-p, --port <PORT>", "Port to serve documentation locally", "8000")
-    .option("-v --verbose", "Enable verbose output.", false)
-    .action(lazy(() => import("./serve/mkdocs").then(m => m.default)));
+    .option('-p, --port <PORT>', 'Port to serve documentation locally', '8000')
+    .option('-v --verbose', 'Enable verbose output.', false)
+    .action(lazy(() => import('./serve/mkdocs').then(m => m.default)));
 
   program
-    .command("serve")
+    .command('serve')
     .description(
-      "Serve a documentation project locally in a Backstage app-like environment"
+      'Serve a documentation project locally in a Backstage app-like environment',
     )
     .option(
-      "-i, --docker-image <DOCKER_IMAGE>",
-      "The mkdocs docker container to use",
-      "spotify/techdocs"
+      '-i, --docker-image <DOCKER_IMAGE>',
+      'The mkdocs docker container to use',
+      'spotify/techdocs',
     )
     .option(
-      "--no-docker",
-      "Do not use Docker, use MkDocs executable in current user environment."
+      '--no-docker',
+      'Do not use Docker, use MkDocs executable in current user environment.',
     )
-    .option("--mkdocs-port <PORT>", "Port for MkDocs server to use", "8000")
-    .option("-v --verbose", "Enable verbose output.", false)
-    .action(lazy(() => import("./serve/serve").then(m => m.default)));
+    .option('--mkdocs-port <PORT>', 'Port for MkDocs server to use', '8000')
+    .option('-v --verbose', 'Enable verbose output.', false)
+    .action(lazy(() => import('./serve/serve').then(m => m.default)));
 }
 
 // Wraps an action function so that it always exits and handles errors
 // Humbly taken from backstage-cli's registerCommands
 function lazy(
-  getActionFunc: () => Promise<(...args: any[]) => Promise<void>>
+  getActionFunc: () => Promise<(...args: any[]) => Promise<void>>,
 ): (...args: any[]) => Promise<never> {
   return async (...args: any[]) => {
     try {

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -149,6 +149,7 @@ export function registerCommands(program: CommanderStatic) {
       external storage, you can set this value to "true" to temporarily revert to
       the old, case-sensitive entity triplet behavior.
       `,
+      false,
     )
     .option(
       '--azureAccountName <AZURE ACCOUNT NAME>',

--- a/packages/techdocs-cli/src/lib/PublisherConfig.ts
+++ b/packages/techdocs-cli/src/lib/PublisherConfig.ts
@@ -60,8 +60,10 @@ export class PublisherConfig {
         }
       },
       techdocs: {
-        publisher: PublisherConfig.configFactories[publisherType](cmd)
-      }
+        publisher: PublisherConfig.configFactories[publisherType](cmd),
+        legacyUseCaseSensitiveTripletPaths:
+          cmd.legacyUseCaseSensitiveTripletPaths,
+      },
     });
   }
 


### PR DESCRIPTION
Refs:
https://github.com/backstage/backstage/issues/4367
https://github.com/backstage/backstage/pull/6709

Adds a new flag called `--legacyUseCaseSensitiveTripletPaths` to enable publishes using the legacy case sensitive triplet paths.

Signed-off-by: Camila Belo <camilaibs@gmail.com>
Co-authored-by: Eric Peterson <ericpeterson@spotify.com>