### PR TITLE
[Chore] Install dependencies before running tsc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/ # Needed for auth
 
+      - name: yarn install
+        run: yarn install --frozen-lockfile
+
       - name: yarn tsc
         run: yarn tsc
 


### PR DESCRIPTION
This is related to the Main Workflow.

We are getting the "_**Error TS2304: Cannot find module**_" when running `yarn tsc`:
https://github.com/backstage/techdocs-cli/runs/3288405993

Added an install step to run before the Typescript compiler.

Signed-off-by: Camila Belo <camilaibs@gmail.com>