### PR TITLE
Add azureAccountKey parameter back to the publish command

### DIFF
--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -151,6 +151,10 @@ export function registerCommands(program: CommanderStatic) {
       '(Required for Azure) specify when --publisher-type azureBlobStorage',
     )
     .option(
+      '--azureAccountKey <AZURE ACCOUNT KEY>',
+      'Azure Storage Account key to use for authentication. If not specified, you must set AZURE_TENANT_ID, AZURE_CLIENT_ID & AZURE_CLIENT_SECRET as environment variables.',
+    )
+    .option(
       '--awsRoleArn <AWS ROLE ARN>',
       'Optional AWS ARN of role to be assumed.',
     )


### PR DESCRIPTION
The azureAccountKey parameter was deleted by misstake so this PR adds it back

closing: #97 