### PR TITLE
Configure dependabot for all packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot version updates configuration.
+# See the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" 
+    directory: "/" 
+    schedule:
+      interval: "daily"
+      
+  - package-ecosystem: "npm"
+    directory: "/packages/embedded-techdocs-app"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/techdocs-cli"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,14 @@ updates:
   - package-ecosystem: "npm" 
     directory: "/" 
     schedule:
-      interval: "daily"
+      interval: "weekly"
       
   - package-ecosystem: "npm"
     directory: "/packages/embedded-techdocs-app"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "npm"
     directory: "/packages/techdocs-cli"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,13 +8,16 @@ updates:
     directory: "/" 
     schedule:
       interval: "weekly"
+      day: "sunday"
       
   - package-ecosystem: "npm"
     directory: "/packages/embedded-techdocs-app"
     schedule:
       interval: "weekly"
+      day: "sunday"
 
   - package-ecosystem: "npm"
     directory: "/packages/techdocs-cli"
     schedule:
       interval: "weekly"
+      day: "sunday"


### PR DESCRIPTION
Configuring dependabot to automatically send us package version updates for all of our dependencies.

[Enable and disable updates.](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-version-updates)