### PR TITLE
ignore dependabot branches for project board workflow

### DIFF
--- a/.github/workflows/project-board.yml
+++ b/.github/workflows/project-board.yml
@@ -9,6 +9,7 @@ on:
     types: [opened, reopened]
   pull_request:
     types: [opened, reopened]
+    branches-ignore: 'dependabot/*'
 
 env:
   MY_GITHUB_TOKEN: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}


### PR DESCRIPTION
Our project board workflow fails when PRs are opened up automatically by dependabot. This adds an exception and ignore the project board workflow on automatically opened dependabot PRs opened from a branch starting with `dependabot`.

[Ref documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-ignoring-branches-and-tags)