### PR TITLE
[Chore]: Separate build and publish release steps

### DIFF
--- a/.changeset/ninety-jars-press.md
+++ b/.changeset/ninety-jars-press.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+Separate build and publish release steps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Compile Files
+        run: yarn tsc
+
+      - name: Build Artifacts
+        run: yarn build
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@master

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "lerna run test -- --coverage",
     "tsc": "tsc",
     "changeset": "changeset add",
-    "release": "yarn tsc & yarn build & changeset publish",
+    "release": "changeset publish",
     "prepare": "husky install"
   },
   "keywords": [


### PR DESCRIPTION
Fixes: https://github.com/backstage/techdocs-cli/issues/151

In the last release, the build script ran after the publish, causing a publish not containing dist files.

![image](https://user-images.githubusercontent.com/6290749/134312241-ccfe9056-8ee6-4645-afbe-5cca96fa9b2d.png)

This pull request aims to separate the build and publish in individual and sequential steps to guarantee the script order.