### PR TITLE
Fix not killing dev server process

### DIFF
--- a/.changeset/thick-toys-cough.md
+++ b/.changeset/thick-toys-cough.md
@@ -2,4 +2,4 @@
 '@techdocs/cli': patch
 ---
 
-Fixes: #176 Detach mkdocs dev server process from parent process
+Fixes: #176 Wait for all child processes to exit before exiting the parent process.

--- a/.changeset/thick-toys-cough.md
+++ b/.changeset/thick-toys-cough.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+Fixes: #176 Detach mkdocs dev server process from parent process

--- a/packages/techdocs-cli/src/commands/serve/serve.ts
+++ b/packages/techdocs-cli/src/commands/serve/serve.ts
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Command } from "commander";
-import path from "path";
-import openBrowser from "react-dev-utils/openBrowser";
-import HTTPServer from "../../lib/httpServer";
-import { runMkdocsServer } from "../../lib/mkdocsServer";
-import { LogFunc, waitForSignal } from "../../lib/run";
-import { createLogger } from "../../lib/utility";
+import { Command } from 'commander';
+import path from 'path';
+import openBrowser from 'react-dev-utils/openBrowser';
+import HTTPServer from '../../lib/httpServer';
+import { runMkdocsServer } from '../../lib/mkdocsServer';
+import { LogFunc, waitForSignal } from '../../lib/run';
+import { createLogger } from '../../lib/utility';
 
 export default async function serve(cmd: Command) {
   const logger = createLogger({ verbose: cmd.verbose });
@@ -27,7 +27,7 @@ export default async function serve(cmd: Command) {
   // Determine if we want to run in local dev mode or not
   // This will run the backstage http server on a different port and only used
   // for proxying mkdocs to the backstage app running locally (e.g. with webpack-dev-server)
-  const isDevMode = Object.keys(process.env).includes("TECHDOCS_CLI_DEV_MODE")
+  const isDevMode = Object.keys(process.env).includes('TECHDOCS_CLI_DEV_MODE')
     ? true
     : false;
 
@@ -44,10 +44,10 @@ export default async function serve(cmd: Command) {
   let mkdocsServerHasStarted = false;
   const mkdocsLogFunc: LogFunc = data => {
     // Sometimes the lines contain an unnecessary extra new line
-    const logLines = data.toString().split("\n");
-    const logPrefix = cmd.docker ? "[docker/mkdocs]" : "[mkdocs]";
+    const logLines = data.toString().split('\n');
+    const logPrefix = cmd.docker ? '[docker/mkdocs]' : '[mkdocs]';
     logLines.forEach(line => {
-      if (line === "") {
+      if (line === '') {
         return;
       }
 
@@ -65,13 +65,13 @@ export default async function serve(cmd: Command) {
   // mkdocs writes all of its logs to stderr by default, and not stdout.
   // https://github.com/mkdocs/mkdocs/issues/879#issuecomment-203536006
   // Had me questioning this whole implementation for half an hour.
-  logger.info("Starting mkdocs server.");
+  logger.info('Starting mkdocs server.');
   const mkdocsChildProcess = await runMkdocsServer({
     port: cmd.mkdocsPort,
     dockerImage: cmd.dockerImage,
     useDocker: cmd.docker,
     stdoutLogFunc: mkdocsLogFunc,
-    stderrLogFunc: mkdocsLogFunc
+    stderrLogFunc: mkdocsLogFunc,
   });
 
   // Wait until mkdocs server has started so that Backstage starts with docs loaded
@@ -81,27 +81,27 @@ export default async function serve(cmd: Command) {
     if (mkdocsServerHasStarted) {
       break;
     }
-    logger.info("Waiting for mkdocs server to start...");
+    logger.info('Waiting for mkdocs server to start...');
   }
 
   if (!mkdocsServerHasStarted) {
     logger.error(
-      "mkdocs server did not start. Exiting. Try re-running command with -v option for more details."
+      'mkdocs server did not start. Exiting. Try re-running command with -v option for more details.',
     );
   }
 
   // Run the embedded-techdocs Backstage app
   const techdocsPreviewBundlePath = path.join(
-    path.dirname(require.resolve("@techdocs/cli/package.json")),
-    "dist",
-    "techdocs-preview-bundle"
+    path.dirname(require.resolve('@techdocs/cli/package.json')),
+    'dist',
+    'techdocs-preview-bundle',
   );
 
   const httpServer = new HTTPServer(
     techdocsPreviewBundlePath,
     isDevMode ? backstageBackendPort : backstagePort,
     cmd.mkdocsPort,
-    cmd.verbose
+    cmd.verbose,
   );
 
   httpServer
@@ -114,12 +114,17 @@ export default async function serve(cmd: Command) {
     .then(() => {
       // The last three things default/component/local/ don't matter. They can be anything.
       openBrowser(
-        `http://localhost:${backstagePort}/docs/default/component/local/`
+        `http://localhost:${backstagePort}/docs/default/component/local/`,
       );
       logger.info(
-        `Serving docs in Backstage at http://localhost:${backstagePort}/docs/default/component/local/\nOpening browser.`
+        `Serving docs in Backstage at http://localhost:${backstagePort}/docs/default/component/local/\nOpening browser.`,
       );
     });
 
-  await waitForSignal([mkdocsChildProcess]);
+  try {
+    await waitForSignal([mkdocsChildProcess]);
+    process.exit(0);
+  } catch {
+    process.exit(1);
+  }
 }

--- a/packages/techdocs-cli/src/e2e.test.ts
+++ b/packages/techdocs-cli/src/e2e.test.ts
@@ -30,18 +30,14 @@ describe('end-to-end', () => {
     );
 
     expect(proc.combinedStdOutErr).toContain('Starting mkdocs server');
-    expect(proc.exit).toEqual(0);
   });
 
   it('can serve in backstage', async () => {
     jest.setTimeout(10000);
-    const proc = await executeTechDocsCliCommand(
-      ['serve', '--no-docker', '--mkdocs-port=8888'],
-      {
-        cwd: '../../',
-        killAfter: 8000,
-      },
-    );
+    const proc = await executeTechDocsCliCommand(['serve', '--no-docker'], {
+      cwd: '../../',
+      killAfter: 8000,
+    });
 
     expect(proc.combinedStdOutErr).toContain('Starting mkdocs server');
     expect(proc.combinedStdOutErr).toContain('Serving docs in Backstage at');

--- a/packages/techdocs-cli/src/lib/run.ts
+++ b/packages/techdocs-cli/src/lib/run.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { spawn, SpawnOptions, ChildProcess } from "child_process";
+import { spawn, SpawnOptions, ChildProcess } from 'child_process';
 
 export type LogFunc = (data: Buffer | string) => void;
-type SpawnOptionsPartialEnv = Omit<SpawnOptions, "env"> & {
+type SpawnOptionsPartialEnv = Omit<SpawnOptions, 'env'> & {
   env?: Partial<NodeJS.ProcessEnv>;
   // Pipe stdout to this log function
   stdoutLogFunc?: LogFunc;
@@ -30,35 +30,36 @@ type SpawnOptionsPartialEnv = Omit<SpawnOptions, "env"> & {
 export const run = async (
   name: string,
   args: string[] = [],
-  options: SpawnOptionsPartialEnv = {}
+  options: SpawnOptionsPartialEnv = {},
 ): Promise<ChildProcess> => {
   const { stdoutLogFunc, stderrLogFunc } = options;
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,
-    FORCE_COLOR: "true",
-    ...(options.env ?? {})
+    FORCE_COLOR: 'true',
+    ...(options.env ?? {}),
   };
 
   // Refer: https://nodejs.org/api/child_process.html#child_process_subprocess_stdio
   const stdio = [
-    "inherit",
-    stdoutLogFunc ? "pipe" : "inherit",
-    stderrLogFunc ? "pipe" : "inherit"
-  ] as ("inherit" | "pipe")[];
+    'inherit',
+    stdoutLogFunc ? 'pipe' : 'inherit',
+    stderrLogFunc ? 'pipe' : 'inherit',
+  ] as ('inherit' | 'pipe')[];
 
   const childProcess = spawn(name, args, {
     stdio: stdio,
     shell: true,
+    detached: true,
     ...options,
-    env
+    env,
   });
 
   if (stdoutLogFunc && childProcess.stdout) {
-    childProcess.stdout.on("data", stdoutLogFunc);
+    childProcess.stdout.on('data', stdoutLogFunc);
   }
   if (stderrLogFunc && childProcess.stderr) {
-    childProcess.stderr.on("data", stderrLogFunc);
+    childProcess.stderr.on('data', stderrLogFunc);
   }
 
   return childProcess;
@@ -68,19 +69,19 @@ export const run = async (
 // Throw error if any child process errors
 // Resolves only when all processes exit with status code 0
 export async function waitForSignal(
-  childProcesses: Array<ChildProcess>
+  childProcesses: Array<ChildProcess>,
 ): Promise<void> {
   const promises: Array<Promise<void>> = [];
 
   childProcesses.forEach(childProcess => {
-    if (typeof childProcess.exitCode === "number") {
+    if (typeof childProcess.exitCode === 'number') {
       if (childProcess.exitCode) {
         throw new Error(`Non zero exit code from child process`);
       }
       return;
     }
 
-    for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
       process.on(signal, () => {
         childProcess.kill(signal);
         // exit instead of resolve. The process is shutting down and resolving a promise here logs an error
@@ -90,15 +91,15 @@ export async function waitForSignal(
 
     promises.push(
       new Promise<void>((resolve, reject) => {
-        childProcess.once("error", error => reject(error));
-        childProcess.once("exit", code => {
+        childProcess.once('error', error => reject(error));
+        childProcess.once('exit', code => {
           if (code) {
             reject(new Error(`Non zero exit code from child process`));
           } else {
             resolve();
           }
         });
-      })
+      }),
     );
   });
 


### PR DESCRIPTION
Fixes: #176, https://github.com/backstage/techdocs-cli/issues/167

## Running locally

Wait for all child processes to exit before exiting the parent process. Previously, we called `process.exit` inside the child's exit handlers causing the parent process to terminate before the Python process terminated. Since the Python process was still running, if we tried to rerun the serve command, the mkdocs server port was already in use, forcing us to have to terminate this process manually.

## Integration test on CI

Removed the `shell` option from the command `serve` because on Linux machines the child process of a child process does not end when the parent process is terminated, commonly in the Shell environment and this caused the Python process to not be terminated between tests, keeping the port of mkdocs server busy (see [documentation](https://nodejs.org/api/child_process.html#subprocesskillsignal)):

```
E2E TEST PROCESS (Parent) ---> TECHDOCS/CLI PROCESS (Child) ---> MKDOCS PROCESS (Child of child, not killed)
```
## How to test

```sh
yarn cli serve --no-docker
```
![serve](https://user-images.githubusercontent.com/6290749/138463933-1cf40a08-72e9-4a75-bdc4-91869c317793.gif)

```sh
yarn cli serve:mkdocs --no-docker
```
![serve mkdocs](https://user-images.githubusercontent.com/6290749/138463973-12d83312-d21c-4499-be4b-54894babe8c5.gif)