### PR TITLE
Support bucketRootPath configuration for AWS and GCS publishers

### DIFF
--- a/.changeset/famous-donuts-warn.md
+++ b/.changeset/famous-donuts-warn.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+Add support for specifying bucketRootPath for AWS and GCS publishers

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -162,6 +162,10 @@ export function registerCommands(program: CommanderStatic) {
       'Optional AWS S3 option to force path style.',
     )
     .option(
+      '--awsBucketRootPath',
+      'Optional sub-directory to store files in Amazon S3',
+    )
+    .option(
       '--osCredentialId <OPENSTACK SWIFT APPLICATION CREDENTIAL ID>',
       '(Required for OpenStack) specify when --publisher-type openStackSwift',
     )
@@ -176,6 +180,10 @@ export function registerCommands(program: CommanderStatic) {
     .option(
       '--osSwiftUrl <OPENSTACK SWIFT SWIFTURL>',
       '(Required for OpenStack) specify when --publisher-type openStackSwift',
+    )
+    .option(
+      '--gcsBucketRootPath',
+      'Optional sub-directory to store files in Google cloud storage',
     )
     .option(
       '--directory <PATH>',

--- a/packages/techdocs-cli/src/lib/PublisherConfig.test.ts
+++ b/packages/techdocs-cli/src/lib/PublisherConfig.test.ts
@@ -68,6 +68,7 @@ describe('getValidPublisherConfig', () => {
       const config = {
         publisherType: 'awsS3',
         storageName: 'someStorageName',
+        awsBucketRootPath: 'backstage-data/techdocs',
       } as unknown as Command;
 
       const actualConfig = PublisherConfig.getValidConfig(config);
@@ -75,6 +76,9 @@ describe('getValidPublisherConfig', () => {
       expect(
         actualConfig.getString('techdocs.publisher.awsS3.bucketName'),
       ).toBe('someStorageName');
+      expect(
+        actualConfig.getString('techdocs.publisher.awsS3.bucketRootPath'),
+      ).toBe('backstage-data/techdocs');
     });
   });
 
@@ -127,6 +131,7 @@ describe('getValidPublisherConfig', () => {
       const config = {
         publisherType: 'googleGcs',
         storageName: 'someStorageName',
+        gcsBucketRootPath: 'backstage-data/techdocs',
       } as unknown as Command;
 
       const actualConfig = PublisherConfig.getValidConfig(config);
@@ -136,6 +141,9 @@ describe('getValidPublisherConfig', () => {
       expect(
         actualConfig.getString('techdocs.publisher.googleGcs.bucketName'),
       ).toBe('someStorageName');
+      expect(
+        actualConfig.getString('techdocs.publisher.googleGcs.bucketRootPath'),
+      ).toBe('backstage-data/techdocs');
     });
   });
 });

--- a/packages/techdocs-cli/src/lib/PublisherConfig.ts
+++ b/packages/techdocs-cli/src/lib/PublisherConfig.ts
@@ -84,6 +84,7 @@ export class PublisherConfig {
       type: 'awsS3',
       awsS3: {
         bucketName: cmd.storageName,
+        ...(cmd.awsBucketRootPath && { bucketRootPath: cmd.awsBucketRootPath }),
         ...(cmd.awsRoleArn && { credentials: { roleArn: cmd.awsRoleArn } }),
         ...(cmd.awsEndpoint && { endpoint: cmd.awsEndpoint }),
         ...(cmd.awsS3ForcePathStyle && { s3ForcePathStyle: true }),
@@ -121,6 +122,7 @@ export class PublisherConfig {
       type: 'googleGcs',
       googleGcs: {
         bucketName: cmd.storageName,
+        ...(cmd.gcsBucketRootPath && { bucketRootPath: cmd.gcsBucketRootPath }),
       },
     };
   }


### PR DESCRIPTION
Resolves #190.

Adds support for specifying the `bucketRootPath` configuration parameter for GCS and AWS publishers in the `publish` command. Option `--awsBucketRootPath` maps to `techdocs.publisher.awsS3.bucketRootPath`. Option `--gcsBucketRootPath` maps to `techdocs.publisher.googleGcs.bucketRootPath`.

This allows an end-user to publish files to a non-root directory in their desired storage bucket.