### PR TITLE
feat: Allow SSE For S3 Buckets

### DIFF
--- a/.changeset/witty-phones-wink.md
+++ b/.changeset/witty-phones-wink.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+Adds ability to use encrypted s3 buckets by utilizing the SSE option in the aws sdk

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "tsc": "tsc",
     "changeset": "changeset add",
     "release": "changeset publish",
+    "postinstall": "yarn tsc",
     "prepare": "husky install"
   },
   "keywords": [

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -161,6 +161,7 @@ export function registerCommands(program: CommanderStatic) {
       '--awsS3ForcePathStyle',
       'Optional AWS S3 option to force path style.',
     )
+    .option('--awsS3sse <AWS SSE>', 'Optional AWS S3 Server Side Encryption.')
     .option(
       '--osCredentialId <OPENSTACK SWIFT APPLICATION CREDENTIAL ID>',
       '(Required for OpenStack) specify when --publisher-type openStackSwift',

--- a/packages/techdocs-cli/src/lib/PublisherConfig.test.ts
+++ b/packages/techdocs-cli/src/lib/PublisherConfig.test.ts
@@ -76,6 +76,20 @@ describe('getValidPublisherConfig', () => {
         actualConfig.getString('techdocs.publisher.awsS3.bucketName'),
       ).toBe('someStorageName');
     });
+
+    it('should return valid ConfigReader with SSE option', () => {
+      const config = {
+        publisherType: 'awsS3',
+        storageName: 'someStorageName',
+        awsS3sse: 'aws:kms',
+      } as unknown as Command;
+
+      const actualConfig = PublisherConfig.getValidConfig(config);
+      expect(actualConfig.getString('techdocs.publisher.type')).toBe('awsS3');
+      expect(actualConfig.getString('techdocs.publisher.awsS3.sse')).toBe(
+        'aws:kms',
+      );
+    });
   });
 
   describe('for openStackSwift', () => {

--- a/packages/techdocs-cli/src/lib/PublisherConfig.ts
+++ b/packages/techdocs-cli/src/lib/PublisherConfig.ts
@@ -87,6 +87,7 @@ export class PublisherConfig {
         ...(cmd.awsRoleArn && { credentials: { roleArn: cmd.awsRoleArn } }),
         ...(cmd.awsEndpoint && { endpoint: cmd.awsEndpoint }),
         ...(cmd.awsS3ForcePathStyle && { s3ForcePathStyle: true }),
+        ...(cmd.awsS3sse && { sse: cmd.awsS3sse }),
       },
     };
   }


### PR DESCRIPTION
closes #68 

**This PR is dependent on a PR in the backstage monorepo**: https://github.com/backstage/backstage/pull/7882

65ef279a42d9b86832aa43a92ba17c46f0e2bed0 - When you first pull down the repo the steps in the `README` don't actually work. I added a post install script that will run once the user has run `yarn install`. Since `tsc` fixed the issue - it seemed like a good thing to have happen automatically for folks. I can remove this if it is out of place, or not necessary, just let me know. 

61aa978c9362bb93848f8e664e57947811b8a3cc - introduces a new flag for `aws` publishes `awsS3sse` which allows the user to pass an optional [Server Side Encryption](https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-s3-encryption.html) type to access their buckets. 

![techdocs-aws-sse](https://user-images.githubusercontent.com/8508556/140179946-e8f436b7-02dc-491b-8f8c-c7c3c7dd1734.png)

